### PR TITLE
Fix Acl json in user_role -> editrules listing

### DIFF
--- a/github_contributions.csv
+++ b/github_contributions.csv
@@ -10284,3 +10284,5 @@ PENDING,Pending
 CANCELED,Canceled
 IN_REVIEW,"In review"
 "System Messages","Messages système"
+"Action Log","Registre des actions",module,Magento_Logging
+"Action Log","Registre des actions",module,Magento_AsynchronousOperations


### PR DESCRIPTION
In the back-end, when we edit a user role, the listing rules names in json string are break.