### PR TITLE
Correct 'Path "%value%" may not include parent directory traversal...'

### DIFF
--- a/github_contributions.csv
+++ b/github_contributions.csv
@@ -10285,3 +10285,4 @@ CANCELED,Canceled
 IN_REVIEW,"In review"
 "System Messages","Messages système"
 "Attachment","Pièce(s) jointe(s)"
+"Path ""%value%"" may not include parent directory traversal (""../"", ""..\"").","Le chemin ""%value%"" ne peut inclure le répertoire parent (""../"", ""..\"").",module,Magento_MediaStorage


### PR DESCRIPTION
There is a double-quote issue in the fr_FR.csv translation file in line 7658.

`"Path ""%value%"" may not include parent directory traversal (""../"", ""..\").","Le chemin ""%value%"" ne peut inclure le répertoire parent (""../"", ""..\").",module,Magento_MediaStorage`

There are 3 translation suggestions in github_contributions.csv, but all three are wrong (first column does not respect the actual label to translate, or the number of double-quote is wrong.

I did not remove these lines, as I don't know if it's the process.